### PR TITLE
Improve run.sh virtual environment activation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Social Media Content Download  |  Gallery Saver
 
 脚本会读取 `sia-desktop` 的配置（默认端口 `18080`），并在首次运行时初始化图库目录与 `images.json`。
 启动成功后在浏览器打开 `http://127.0.0.1:18080` 即可访问在线图库页面。
+脚本会自动检测虚拟环境的激活脚本，无论是类 Unix 系统的 `bin/activate` 还是 Windows 的 `Scripts/activate` 都能正确处理。

--- a/run.sh
+++ b/run.sh
@@ -16,8 +16,17 @@ if [ ! -d "$VENV_DIR" ]; then
   "$PYTHON_BIN" -m venv "$VENV_DIR"
 fi
 
+ACTIVATE_SCRIPT="$VENV_DIR/bin/activate"
+if [ ! -f "$ACTIVATE_SCRIPT" ]; then
+  ACTIVATE_SCRIPT="$VENV_DIR/Scripts/activate"
+  if [ ! -f "$ACTIVATE_SCRIPT" ]; then
+    echo "[ERROR] 未找到虚拟环境激活脚本：$VENV_DIR/bin/activate 或 $VENV_DIR/Scripts/activate" >&2
+    exit 1
+  fi
+fi
+
 # shellcheck disable=SC1090
-source "$VENV_DIR/bin/activate"
+source "$ACTIVATE_SCRIPT"
 
 python -m pip install --upgrade pip wheel
 python -m pip install -e "$APP_DIR"


### PR DESCRIPTION
## Summary
- add cross-platform detection of the virtual environment activation script in run.sh
- update README to mention automatic activation script detection for Windows users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbcc0f3b10832f862701324ec08da7