### PR TITLE
Add Windows launcher script and enhance interpreter detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,20 @@ Social Media Content Download  |  Gallery Saver
 
 克隆仓库后执行以下命令即可自动创建虚拟环境、安装依赖并启动本地服务：
 
-```bash
-./run.sh
-```
+- macOS/Linux（或 Windows 上的 Git Bash 等类 Unix 终端）
+
+  ```bash
+  ./run.sh
+  ```
+
+- Windows 命令提示符（CMD）：
+
+  ```cmd
+  run.cmd
+  ```
+
+  也可以在资源管理器中双击 `run.cmd` 一键启动。
 
 脚本会读取 `sia-desktop` 的配置（默认端口 `18080`），并在首次运行时初始化图库目录与 `images.json`。
 启动成功后在浏览器打开 `http://127.0.0.1:18080` 即可访问在线图库页面。
-脚本会自动检测虚拟环境的激活脚本，无论是类 Unix 系统的 `bin/activate` 还是 Windows 的 `Scripts/activate` 都能正确处理。
+脚本会自动检测虚拟环境的激活脚本，无论是类 Unix 系统的 `bin/activate` 还是 Windows 的 `Scripts/activate` 都能正确处理；Windows 批处理脚本还会自动搜索已安装的 `python`/`py`，兼容 Python 3.10、3.11 和 3.12。

--- a/run.cmd
+++ b/run.cmd
@@ -1,0 +1,129 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "ROOT_DIR=%~dp0"
+if "%ROOT_DIR:~-1%"=="\" set "ROOT_DIR=%ROOT_DIR:~0,-1%"
+set "APP_DIR=%ROOT_DIR%\sia-desktop"
+set "VENV_DIR=%ROOT_DIR%\.venv"
+set "EXIT_CODE=0"
+set "PUSHED="
+
+pushd "%ROOT_DIR%" >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] 无法进入项目目录 %ROOT_DIR%。
+  set "EXIT_CODE=1"
+  goto :exit
+)
+set "PUSHED=1"
+
+set "PYTHON_EXE="
+set "PYTHON_ARGS="
+
+if defined PYTHON (
+  call :parse_python "%PYTHON%"
+) else (
+  for %%C in ("py|-3.12" "py|-3.11" "py|-3.10" "py|-3" "python3" "python") do (
+    if not defined PYTHON_EXE (
+      for /f "tokens=1,2 delims=|" %%I in ("%%~C") do (
+        call :test_python "%%~I" "%%~J"
+      )
+    )
+  )
+)
+
+if not defined PYTHON_EXE (
+  echo [ERROR] 未找到可用的 Python 3.10+ 解释器。请安装 Python 3.10 及以上版本，或设置 PYTHON 环境变量后重试。
+  set "EXIT_CODE=1"
+  goto :exit
+)
+
+echo [INFO] 使用 Python 解释器: %PYTHON_EXE% %PYTHON_ARGS%
+
+if not exist "%VENV_DIR%\Scripts\python.exe" (
+  echo [INFO] 创建虚拟环境 "%VENV_DIR%"
+  call :run_python -m venv "%VENV_DIR%"
+  if errorlevel 1 (
+    echo [ERROR] 创建虚拟环境失败。
+    set "EXIT_CODE=1"
+    goto :exit
+  )
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+if errorlevel 1 (
+  echo [ERROR] 激活虚拟环境失败。
+  set "EXIT_CODE=1"
+  goto :exit
+)
+
+call :run_python -m pip install --upgrade pip wheel
+if errorlevel 1 goto :pip_error
+call :run_python -m pip install -e "%APP_DIR%"
+if errorlevel 1 goto :pip_error
+
+set "_TMP_PORT=%TEMP%\sia_port_%RANDOM%.txt"
+call :run_python -c "from sia.core.config import CONFIG; print(CONFIG.get().port)" >"%_TMP_PORT%"
+if errorlevel 1 goto :python_error
+set /p PORT=<"%_TMP_PORT%"
+del "%_TMP_PORT%" >nul 2>&1
+
+call :run_python -c ^
+"from sia.core.config import CONFIG; ^
+cfg = CONFIG.get(); ^
+cfg.base_dir.mkdir(parents=True, exist_ok=True); ^
+images = cfg.base_dir / 'images.json'; ^
+import json; ^
+if not images.exists(): ^
+    images.write_text('[]', encoding='utf-8'); ^
+print('图库目录:', cfg.base_dir); ^
+print('索引文件:', images)"
+if errorlevel 1 goto :python_error
+
+echo [INFO] 启动服务: http://127.0.0.1:%PORT%
+call :run_python -m uvicorn sia.server.api:app --host 0.0.0.0 --port %PORT%
+set "EXIT_CODE=%errorlevel%"
+goto :exit
+
+:pip_error
+echo [ERROR] 依赖安装失败。
+set "EXIT_CODE=1"
+goto :exit
+
+:python_error
+echo [ERROR] 初始化图库目录失败。
+if defined _TMP_PORT if exist "%_TMP_PORT%" del "%_TMP_PORT%" >nul 2>&1
+set "EXIT_CODE=1"
+goto :exit
+
+:parse_python
+set "PYTHON_CMD=%~1"
+for /f "tokens=1*" %%I in ("%PYTHON_CMD%") do (
+  set "PYTHON_EXE=%%~I"
+  set "PYTHON_ARGS=%%~J"
+)
+exit /b
+
+:test_python
+set "_EXE=%~1"
+set "_ARGS=%~2"
+call :run_command "%_EXE%" %_ARGS% -c "import sys; assert sys.version_info >= (3, 10)" >nul 2>&1
+if not errorlevel 1 (
+  set "PYTHON_EXE=%_EXE%"
+  set "PYTHON_ARGS=%_ARGS%"
+)
+exit /b
+
+:run_python
+call :run_command "%PYTHON_EXE%" %PYTHON_ARGS% %*
+exit /b %errorlevel%
+
+:run_command
+set "_EXE=%~1"
+shift
+"%_EXE%" %*
+exit /b %errorlevel%
+
+:exit
+if defined PUSHED popd >nul 2>&1
+set "_EXIT=%EXIT_CODE%"
+endlocal & exit /b %_EXIT%

--- a/run.sh
+++ b/run.sh
@@ -4,16 +4,40 @@ set -euo pipefail
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 APP_DIR="$ROOT_DIR/sia-desktop"
 VENV_DIR="$ROOT_DIR/.venv"
-PYTHON_BIN=${PYTHON:-python3}
 
-if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
-  echo "[ERROR] 未找到 Python 解释器：$PYTHON_BIN" >&2
+if [ -n "${PYTHON:-}" ]; then
+  IFS=' ' read -r -a PYTHON_BIN <<<"$PYTHON"
+else
+  PYTHON_BIN=()
+  while IFS= read -r candidate; do
+    IFS=' ' read -r -a parts <<<"$candidate"
+    if "${parts[@]}" -c 'import sys; assert sys.version_info >= (3, 10)' >/dev/null 2>&1; then
+      PYTHON_BIN=("${parts[@]}")
+      break
+    fi
+  done <<'CANDIDATES'
+python3
+python3.12
+python3.11
+python
+py -3.12
+py -3.11
+py -3.10
+py -3
+CANDIDATES
+fi
+
+if [ ${#PYTHON_BIN[@]} -eq 0 ]; then
+  echo "[ERROR] 未找到可用的 Python 3.10+ 解释器，请安装后重试，或者通过设置 PYTHON 环境变量指定解释器。" >&2
   exit 1
 fi
 
+PYTHON_DISPLAY="${PYTHON_BIN[*]}"
+echo "[INFO] 使用 Python 解释器：$PYTHON_DISPLAY"
+
 if [ ! -d "$VENV_DIR" ]; then
   echo "[INFO] 创建虚拟环境 $VENV_DIR"
-  "$PYTHON_BIN" -m venv "$VENV_DIR"
+  "${PYTHON_BIN[@]}" -m venv "$VENV_DIR"
 fi
 
 ACTIVATE_SCRIPT="$VENV_DIR/bin/activate"
@@ -28,16 +52,16 @@ fi
 # shellcheck disable=SC1090
 source "$ACTIVATE_SCRIPT"
 
-python -m pip install --upgrade pip wheel
-python -m pip install -e "$APP_DIR"
+"${PYTHON_BIN[@]}" -m pip install --upgrade pip wheel
+"${PYTHON_BIN[@]}" -m pip install -e "$APP_DIR"
 
-PORT=$(python - <<'PY'
+PORT=$("${PYTHON_BIN[@]}" - <<'PY'
 from sia.core.config import CONFIG
 print(CONFIG.get().port)
 PY
 )
 
-python - <<'PY'
+"${PYTHON_BIN[@]}" - <<'PY'
 from pathlib import Path
 from sia.core.config import CONFIG
 


### PR DESCRIPTION
## Summary
- add a Windows `run.cmd` helper that locates Python 3.10+ and mirrors the setup/start workflow
- make the existing `run.sh` fall back to common Python/py launchers when `python3` is unavailable
- document the separate launch commands for Unix shells and Windows CMD in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbceb35d80832f99039add893b3d51